### PR TITLE
Street Easy

### DIFF
--- a/recipes/street_easy/build.py
+++ b/recipes/street_easy/build.py
@@ -1,0 +1,33 @@
+import sys
+import pandas as pd
+
+# Read input data
+cols = [
+        "nta_name",
+        "nta_code",
+        "no._of_new_sale_listings",
+        "no._of_pending_sale_listings",
+        "no._of_sale_listings",
+        "pct_hike_(sales)",
+        "pct_cut_(sales)",
+        "median_weeks_on_market_(sales)",
+        "no._of_new_rental_listings",
+        "no._of_pending_listings",
+        "no._of_rental_listings",
+        "pct_hike_(rentals)",
+        "pct_cut_(rentals)",
+        "pct_furnished_(rentals)",
+        "pct_short_term_(rentals)",
+        "pct_with_concessions_(rentals)",
+        "median_weeks_on_market_(rentals)",
+        "week_start_date",
+        "week_end_date"
+    ]
+
+df = pd.read_csv("input/street_easy_latest.csv")
+
+df.columns = [i.lower().replace(" ", "_") for i in df.columns]
+for col in cols:
+    assert col in df.columns
+
+df.to_csv(sys.stdout, sep='|', index=False)

--- a/recipes/street_easy/build.py
+++ b/recipes/street_easy/build.py
@@ -1,5 +1,8 @@
+import os
 import sys
 import pandas as pd
+
+street_easy_aws = os.environ.get('STREET_EASY_AWS')
 
 # Read input data
 cols = [
@@ -24,7 +27,7 @@ cols = [
         "week_end_date"
     ]
 
-df = pd.read_csv("input/street_easy_latest.csv")
+df = pd.read_csv(f"{street_easy_aws}/nta/nta-metrics-2020-06-01.csv")
 
 df.columns = [i.lower().replace(" ", "_") for i in df.columns]
 for col in cols:

--- a/recipes/street_easy/build.py
+++ b/recipes/street_easy/build.py
@@ -30,4 +30,12 @@ df.columns = [i.lower().replace(" ", "_") for i in df.columns]
 for col in cols:
     assert col in df.columns
 
-df.to_csv(sys.stdout, sep='|', index=False)
+for col in ["no._of_new_sale_listings",
+            "no._of_pending_sale_listings",
+            "no._of_sale_listings",
+            "no._of_new_rental_listings",
+            "no._of_pending_listings",
+            "no._of_rental_listings"]:
+    df[col] = df[col].fillna(0).astype(int)
+    
+df[cols].to_csv(sys.stdout, sep='|', index=False)

--- a/recipes/street_easy/build.py
+++ b/recipes/street_easy/build.py
@@ -2,7 +2,7 @@ import os
 import sys
 import pandas as pd
 
-street_easy_aws = os.environ.get('STREET_EASY_AWS')
+url = os.environ.get('URL_STREET_EASY')
 
 # Read input data
 cols = [
@@ -27,7 +27,7 @@ cols = [
         "week_end_date"
     ]
 
-df = pd.read_csv(f"{street_easy_aws}/nta/nta-metrics-2020-06-01.csv")
+df = pd.read_csv(f"{url}/nta/nta-metrics-2020-06-01.csv")
 
 df.columns = [i.lower().replace(" ", "_") for i in df.columns]
 for col in cols:

--- a/recipes/street_easy/create.sql
+++ b/recipes/street_easy/create.sql
@@ -26,6 +26,7 @@ CREATE TEMP TABLE tmp(
 CREATE SCHEMA IF NOT EXISTS :NAME;
 DROP TABLE IF EXISTS :NAME.:"VERSION" CASCADE;
 SELECT 
+    to_char(a.week_start, 'IYYY-IW') as year_week,
     a.nta_name,
     a.nta_code,
     a.s_newlist,
@@ -43,8 +44,6 @@ SELECT
     ROUND(a.r_pct_shor*100, 2) as r_pct_shor,
     ROUND(a.r_pct_con*100, 2) as r_pct_con,
     ROUND(a.r_wksonmkt, 1) as r_wksonmkt,
-    week_start,
-    week_end,
     b.wkb_geometry as geom
 INTO :NAME.:"VERSION"
 FROM tmp a

--- a/recipes/street_easy/create.sql
+++ b/recipes/street_easy/create.sql
@@ -1,0 +1,60 @@
+CREATE TEMP TABLE tmp(
+    nta_name text,
+    nta_code varchar(4),
+    s_newlist int,
+    s_pendlist int,
+    s_list int,
+    s_pct_inc double precision,
+    s_pct_dec double precision,
+    s_wksonmkt double precision,
+    r_newlist int,
+    r_pendlist int,
+    r_list int,
+    r_pct_inc double precision,
+    r_pct_dec double precision,
+    r_pct_furn double precision,
+    r_pct_shor double precision,
+    r_pct_con double precision,
+    r_wksonmkt double precision,
+    week_start timestamp,
+    week_end timestamp
+)
+
+
+\COPY tmp FROM PSTDIN DELIMITER '|' CSV HEADER;
+
+-- Join with NTA geometry and round
+CREATE SCHEMA IF NOT EXISTS :NAME;
+DROP TABLE IF EXISTS :NAME.:"VERSION" CASCADE;
+SELECT 
+    a.nta_name,
+    a.nta_code,
+    a.s_newlist,
+    a.s_pendlist,
+    a.s_list,
+    ROUND(a.s_pct_inc*100, 2) as s_pct_inc,
+    ROUND(a.s_pct_dec*100, 2) as s_pct_dec,
+    ROUND(a.s_wksonmkt, 1) as s_wksonmkt,
+    a.r_newlist,
+    a.r_pendlist,
+    a.r_list,
+    ROUND(a.r_pct_inc*100, 2) as r_pct_inc,
+    ROUND(a.r_pct_dec*100, 2) as r_pct_dec,
+    ROUND(a.r_pct_furn*100, 2) as r_pct_furn,
+    ROUND(a.r_pct_shor*100, 2) as r_pct_shor,
+    ROUND(a.r_pct_con*100, 2) as r_pct_con,
+    ROUND(a.r_wksonmkt, 1) as r_wksonmkt,
+    week_start timestamp,
+    week_end timestamp,
+    b.geom
+INTO :NAME.:"VERSION"
+FROM tmp a
+JOIN dcp_ntaboundaries b
+ON a.nta_code = b.ntacode
+;
+
+DROP VIEW IF EXISTS :NAME.latest;
+CREATE VIEW :NAME.latest AS (
+    SELECT :'VERSION' as v, * 
+    FROM :NAME.:"VERSION"
+); 

--- a/recipes/street_easy/create.sql
+++ b/recipes/street_easy/create.sql
@@ -4,22 +4,21 @@ CREATE TEMP TABLE tmp(
     s_newlist int,
     s_pendlist int,
     s_list int,
-    s_pct_inc double precision,
-    s_pct_dec double precision,
-    s_wksonmkt double precision,
+    s_pct_inc decimal,
+    s_pct_dec decimal,
+    s_wksonmkt decimal,
     r_newlist int,
     r_pendlist int,
     r_list int,
-    r_pct_inc double precision,
-    r_pct_dec double precision,
-    r_pct_furn double precision,
-    r_pct_shor double precision,
-    r_pct_con double precision,
-    r_wksonmkt double precision,
+    r_pct_inc decimal,
+    r_pct_dec decimal,
+    r_pct_furn decimal,
+    r_pct_shor decimal,
+    r_pct_con decimal,
+    r_wksonmkt decimal,
     week_start timestamp,
     week_end timestamp
-)
-
+);
 
 \COPY tmp FROM PSTDIN DELIMITER '|' CSV HEADER;
 
@@ -44,9 +43,9 @@ SELECT
     ROUND(a.r_pct_shor*100, 2) as r_pct_shor,
     ROUND(a.r_pct_con*100, 2) as r_pct_con,
     ROUND(a.r_wksonmkt, 1) as r_wksonmkt,
-    week_start timestamp,
-    week_end timestamp,
-    b.geom
+    week_start,
+    week_end,
+    b.wkb_geometry as geom
 INTO :NAME.:"VERSION"
 FROM tmp a
 JOIN dcp_ntaboundaries b

--- a/recipes/street_easy/runner.sh
+++ b/recipes/street_easy/runner.sh
@@ -23,6 +23,9 @@ VERSION=$DATE
             SELECT * FROM $NAME.\"$VERSION\"
         ) TO stdout DELIMITER ',' CSV HEADER;" > street_easy_nta.csv
 
+        # Export to ShapeFile
+        SHP_export $RDP_DATA $NAME.latest MULTIPOLYGON street_easy_nta
+
         # Write VERSION info
         echo "$VERSION" > version.txt
 

--- a/recipes/street_easy/runner.sh
+++ b/recipes/street_easy/runner.sh
@@ -11,6 +11,7 @@ VERSION=$DATE
     docker run --rm\
             -v $(pwd)/../:/recipes\
             -e NAME=$NAME\
+            -e STREET_EASY_AWS=$STREET_EASY_AWS\
             -w /recipes/$NAME\
             nycplanning/cook:latest python3 build.py | 
     psql $RDP_DATA -v NAME=$NAME -v VERSION=$VERSION -f create.sql

--- a/recipes/street_easy/runner.sh
+++ b/recipes/street_easy/runner.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+source $(pwd)/bin/config.sh
+BASEDIR=$(dirname $0)
+NAME=$(basename $BASEDIR)
+VERSION=$DATE
+
+(
+    cd $BASEDIR
+    mkdir -p output
+
+    docker run --rm\
+            -v $(pwd)/../:/recipes\
+            -e NAME=$NAME\
+            -w /recipes/$NAME\
+            nycplanning/cook:latest python3 build.py | 
+    psql $RDP_DATA -v NAME=$NAME -v VERSION=$VERSION -f create.sql
+
+    (
+        cd output
+
+        # Export to CSV
+        psql $RDP_DATA -c "\COPY (
+            SELECT * FROM $NAME.\"$VERSION\"
+        ) TO stdout DELIMITER ',' CSV HEADER;" > street_easy_nta.csv
+
+        # Write VERSION info
+        echo "$VERSION" > version.txt
+
+    )
+) 


### PR DESCRIPTION
#2 

Workflow for Street Easy data:
+ Read raw data (currently from local file, since we do not yet have agreement on how to acquire data) into pandas
+ Assert that all necessary columns exist
+ Convert count columns to integer
+ Transfer to RDP_DATA using std
+ Create `year_week` to match Upsolve
+ Rename columns
+ Round values: two decimals for percentages, one for median weeks on market
+ Output fields with `pct` as percentages and not as rates

## To-Do: 
- [ ] figure out source data ingestion 
- [ ] documentation