### PR TITLE
Filter daily table to NY market area

### DIFF
--- a/recipes/cuebiq/create_daily.sql
+++ b/recipes/cuebiq/create_daily.sql
@@ -130,17 +130,17 @@ DROP TABLE IF EXISTS :NAME.:"VERSION" CASCADE;
 SELECT * 
 INTO :NAME.:"VERSION"
 FROM (
-    (SELECT * FROM automotive) UNION
-    (SELECT * FROM dining) UNION
-    (SELECT * FROM healthcare) UNION
-    (SELECT * FROM lifestyle) UNION
-    (SELECT * FROM malls) UNION
-    (SELECT * FROM retail) UNION
-    (SELECT * FROM telco) UNION
+    (SELECT * FROM automotive WHERE market_area_code = '501') UNION
+    (SELECT * FROM dining WHERE market_area_code = '501') UNION
+    (SELECT * FROM healthcare WHERE market_area_code = '501') UNION
+    (SELECT * FROM lifestyle WHERE market_area_code = '501') UNION
+    (SELECT * FROM malls WHERE market_area_code = '501') UNION
+    (SELECT * FROM retail WHERE market_area_code = '501') UNION
+    (SELECT * FROM telco WHERE market_area_code = '501') UNION
     (SELECT *, 
         NULL::numeric as roll_avg_7days_cvi_per_store,
         NULL::numeric as ly_roll_avg_7days_cvi_per_store
-    FROM transportation)
+    FROM transportation WHERE market_area_code = '501')
 ) a;
 
 DROP VIEW IF EXISTS :NAME.latest;


### PR DESCRIPTION
#45 

Filters cuebiq daily data to NYC market area only.
None of the other NY/CT/NJ market areas were within NYC region.

Sample output is in `cuebiq_daily.filtered`.