### PR TITLE
Cuebiq enhancements

### DIFF
--- a/recipes/cuebiq/create.sql
+++ b/recipes/cuebiq/create.sql
@@ -12,7 +12,14 @@ CREATE TEMP TABLE tmp (
 
 CREATE SCHEMA IF NOT EXISTS :NAME;
 DROP TABLE IF EXISTS :NAME.:"VERSION" CASCADE;
-SELECT DISTINCT *
+SELECT DISTINCT
+    reference_date,
+    REPLACE(week_name, 'W', '') as year_week,
+    county_name as county,
+    state_name as state,
+    census_block_group_id,
+    ROUND(mobility_index, 8)  as mobility_index,
+    weight
 INTO :NAME.:"VERSION"
 FROM tmp;
 

--- a/recipes/cuebiq/create_daily.sql
+++ b/recipes/cuebiq/create_daily.sql
@@ -128,17 +128,17 @@ CREATE TEMP TABLE transportation (
 CREATE SCHEMA IF NOT EXISTS :NAME;
 DROP TABLE IF EXISTS :NAME.:"VERSION" CASCADE;
 WITH all_sectors AS (
-    (SELECT * FROM automotive WHERE market_area_code = '501') UNION
-    (SELECT * FROM dining WHERE market_area_code = '501') UNION
-    (SELECT * FROM healthcare WHERE market_area_code = '501') UNION
-    (SELECT * FROM lifestyle WHERE market_area_code = '501') UNION
-    (SELECT * FROM malls WHERE market_area_code = '501') UNION
-    (SELECT * FROM retail WHERE market_area_code = '501') UNION
-    (SELECT * FROM telco WHERE market_area_code = '501') UNION
+    (SELECT * FROM automotive) UNION
+    (SELECT * FROM dining) UNION
+    (SELECT * FROM healthcare) UNION
+    (SELECT * FROM lifestyle) UNION
+    (SELECT * FROM malls) UNION
+    (SELECT * FROM retail) UNION
+    (SELECT * FROM telco) UNION
     (SELECT *, 
         NULL::numeric as roll_avg_7days_cvi_per_store,
         NULL::numeric as ly_roll_avg_7days_cvi_per_store
-    FROM transportation WHERE market_area_code = '501')
+    FROM transportation)
 )
 SELECT 
     reference_date,

--- a/recipes/cuebiq/create_daily.sql
+++ b/recipes/cuebiq/create_daily.sql
@@ -128,17 +128,17 @@ CREATE TEMP TABLE transportation (
 CREATE SCHEMA IF NOT EXISTS :NAME;
 DROP TABLE IF EXISTS :NAME.:"VERSION" CASCADE;
 WITH all_sectors AS (
-    (SELECT * FROM automotive) UNION
-    (SELECT * FROM dining) UNION
-    (SELECT * FROM healthcare) UNION
-    (SELECT * FROM lifestyle) UNION
-    (SELECT * FROM malls) UNION
-    (SELECT * FROM retail) UNION
-    (SELECT * FROM telco) UNION
+    (SELECT * FROM automotive WHERE market_area_code = '501') UNION
+    (SELECT * FROM dining WHERE market_area_code = '501') UNION
+    (SELECT * FROM healthcare WHERE market_area_code = '501') UNION
+    (SELECT * FROM lifestyle WHERE market_area_code = '501') UNION
+    (SELECT * FROM malls WHERE market_area_code = '501') UNION
+    (SELECT * FROM retail WHERE market_area_code = '501') UNION
+    (SELECT * FROM telco WHERE market_area_code = '501') UNION
     (SELECT *, 
         NULL::numeric as roll_avg_7days_cvi_per_store,
         NULL::numeric as ly_roll_avg_7days_cvi_per_store
-    FROM transportation)
+    FROM transportation WHERE market_area_code = '501')
 )
 SELECT 
     reference_date,
@@ -160,11 +160,4 @@ DROP VIEW IF EXISTS :NAME.latest;
 CREATE VIEW :NAME.latest AS (
     SELECT :'VERSION' as v, * 
     FROM :NAME.:"VERSION"
-);
-
-DROP VIEW IF EXISTS :NAME.nyc_latest;
-CREATE VIEW :NAME.nyc_latest AS (
-    SELECT :'VERSION' as v, * 
-    FROM :NAME.:"VERSION"
-    WHERE market_area_code = '501'
 );

--- a/recipes/cuebiq/create_daily.sql
+++ b/recipes/cuebiq/create_daily.sql
@@ -127,9 +127,7 @@ CREATE TEMP TABLE transportation (
 
 CREATE SCHEMA IF NOT EXISTS :NAME;
 DROP TABLE IF EXISTS :NAME.:"VERSION" CASCADE;
-SELECT * 
-INTO :NAME.:"VERSION"
-FROM (
+WITH all_sectors AS (
     (SELECT * FROM automotive WHERE market_area_code = '501') UNION
     (SELECT * FROM dining WHERE market_area_code = '501') UNION
     (SELECT * FROM healthcare WHERE market_area_code = '501') UNION
@@ -141,10 +139,32 @@ FROM (
         NULL::numeric as roll_avg_7days_cvi_per_store,
         NULL::numeric as ly_roll_avg_7days_cvi_per_store
     FROM transportation WHERE market_area_code = '501')
-) a;
+)
+SELECT 
+    reference_date,
+    to_char(reference_date::date, 'IYYY-IW') as year_week,
+    market_area_code,
+    market_area,
+    sector,
+    vertical,
+    brand,
+    naics6_code,
+    ROUND(roll_avg_7days_cvi, 4) as roll_avg_7days_cvi,
+    ROUND(ly_roll_avg_7days_cvi, 4) as ly_roll_avg_7days_cvi,
+    ROUND(roll_avg_7days_cvi_per_store, 4) as roll_avg_7days_cvi_per_store,
+    ROUND(ly_roll_avg_7days_cvi_per_store, 4) as ly_roll_avg_7days_cvi_per_store
+INTO :NAME.:"VERSION"
+FROM all_sectors;
 
 DROP VIEW IF EXISTS :NAME.latest;
 CREATE VIEW :NAME.latest AS (
     SELECT :'VERSION' as v, * 
     FROM :NAME.:"VERSION"
+);
+
+DROP VIEW IF EXISTS :NAME.nyc_latest;
+CREATE VIEW :NAME.nyc_latest AS (
+    SELECT :'VERSION' as v, * 
+    FROM :NAME.:"VERSION"
+    WHERE market_area_code = '501'
 );

--- a/recipes/cuebiq/create_weekly.sql
+++ b/recipes/cuebiq/create_weekly.sql
@@ -24,17 +24,11 @@ SELECT
     ROUND(cvi, 4) as cvi,
     ROUND(cvi_per_store, 4) as cvi_per_store
 INTO :NAME.:"VERSION"
-FROM tmp;
+FROM tmp
+WHERE market_area_code = '501';
 
 DROP VIEW IF EXISTS :NAME.latest;
 CREATE VIEW :NAME.latest AS (
     SELECT :'VERSION' as v, * 
     FROM :NAME.:"VERSION"
-);
-
-DROP VIEW IF EXISTS :NAME.nyc_latest;
-CREATE VIEW :NAME.nyc_latest AS (
-    SELECT :'VERSION' as v, * 
-    FROM :NAME.:"VERSION"
-    WHERE market_area_code = '501'
 );

--- a/recipes/cuebiq/create_weekly.sql
+++ b/recipes/cuebiq/create_weekly.sql
@@ -10,13 +10,19 @@ CREATE TEMP TABLE tmp (
     cvi_per_store numeric
 );
 
-\COPY tmp FROM PPROGRAM 'gzip -dc input/daily-cvi-automotive.csv000.gz' DELIMITER ',' CSV HEADER;
-
--- \COPY tmp FROM PSTDIN DELIMITER ',' CSV QUOTE '"';
+\COPY tmp FROM PSTDIN DELIMITER ',' CSV QUOTE '"';
 
 CREATE SCHEMA IF NOT EXISTS :NAME;
 DROP TABLE IF EXISTS :NAME.:"VERSION" CASCADE;
-SELECT *
+SELECT 
+    REPLACE(visit_week_cd, 'W', '') as year_week,
+    market_area_code,
+    market_area,
+    sector,
+    vertical,
+    brand,
+    ROUND(cvi, 4) as cvi,
+    ROUND(cvi_per_store, 4) as cvi
 INTO :NAME.:"VERSION"
 FROM tmp;
 
@@ -24,4 +30,11 @@ DROP VIEW IF EXISTS :NAME.latest;
 CREATE VIEW :NAME.latest AS (
     SELECT :'VERSION' as v, * 
     FROM :NAME.:"VERSION"
+);
+
+DROP VIEW IF EXISTS :NAME.nyc_latest;
+CREATE VIEW :NAME.nyc_latest AS (
+    SELECT :'VERSION' as v, * 
+    FROM :NAME.:"VERSION"
+    WHERE market_area_code = '501'
 );

--- a/recipes/cuebiq/create_weekly.sql
+++ b/recipes/cuebiq/create_weekly.sql
@@ -22,7 +22,7 @@ SELECT
     vertical,
     brand,
     ROUND(cvi, 4) as cvi,
-    ROUND(cvi_per_store, 4) as cvi
+    ROUND(cvi_per_store, 4) as cvi_per_store
 INTO :NAME.:"VERSION"
 FROM tmp;
 

--- a/recipes/cuebiq/runner.sh
+++ b/recipes/cuebiq/runner.sh
@@ -79,9 +79,6 @@ case $TYPE in
                 SELECT * FROM $NAME.\"$VERSION\"
             ) TO stdout DELIMITER ',' CSV HEADER;" > $NAME.csv
 
-            psql $RDP_DATA -c "\COPY (
-                SELECT * FROM $NAME.nyc_latest
-            ) TO stdout DELIMITER ',' CSV HEADER;" > nyc_$NAME.csv
         )
         Upload $NAME $VERSION
         Upload $NAME latest
@@ -115,10 +112,7 @@ case $TYPE in
             ) TO stdout DELIMITER ',' CSV HEADER;" > $NAME.csv
             zip $NAME.zip $NAME.csv
             rm $NAME.csv
-
-            psql $RDP_DATA -c "\COPY (
-                SELECT * FROM $NAME.nyc_latest
-            ) TO stdout DELIMITER ',' CSV HEADER;" > nyc_$NAME.csv
+            
         )
         Upload $NAME $VERSION
         Upload $NAME latest

--- a/recipes/cuebiq/runner.sh
+++ b/recipes/cuebiq/runner.sh
@@ -78,6 +78,10 @@ case $TYPE in
             psql $RDP_DATA -c "\COPY (
                 SELECT * FROM $NAME.\"$VERSION\"
             ) TO stdout DELIMITER ',' CSV HEADER;" > $NAME.csv
+
+            psql $RDP_DATA -c "\COPY (
+                SELECT * FROM $NAME.nyc_latest
+            ) TO stdout DELIMITER ',' CSV HEADER;" > nyc_$NAME.csv
         )
         Upload $NAME $VERSION
         Upload $NAME latest
@@ -111,6 +115,10 @@ case $TYPE in
             ) TO stdout DELIMITER ',' CSV HEADER;" > $NAME.csv
             zip $NAME.zip $NAME.csv
             rm $NAME.csv
+
+            psql $RDP_DATA -c "\COPY (
+                SELECT * FROM $NAME.nyc_latest
+            ) TO stdout DELIMITER ',' CSV HEADER;" > nyc_$NAME.csv
         )
         Upload $NAME $VERSION
         Upload $NAME latest


### PR DESCRIPTION
#17 

+ Standardize week identifiers to `IYYY-IW` format `year_week`
+ Round indices
+ Standardize field names
+ For `weekly` and `daily`, produce an unfiltered table as well as a NYC-only view