### PR TITLE
Normalize - BetaNYC

### DIFF
--- a/recipes/betanyc/runner.sh
+++ b/recipes/betanyc/runner.sh
@@ -20,7 +20,9 @@ VERSION=$DATE
         # Export to CSV
         psql $RDP_DATA -c "\COPY (
             SELECT * FROM $NAME.\"$VERSION\"
-        ) TO stdout DELIMITER ',' CSV HEADER;" > $NAME.csv
+        ) TO stdout DELIMITER ',' CSV HEADER;" > betanyc_businesses.csv
+
+        SHP_export $RDP_DATA $NAME.latest POINT betanyc_businesses.shp
 
         # Write VERSION info
         echo "$VERSION" > version.txt


### PR DESCRIPTION
#78 

- phone number not normalized
- I'm ambivalent about using geosupport address, because not all addresses geocoded, and original addresses contain varying level of information, sometimes borough/neighborhood/zipcode/city. if we were to standardize by just housenumber and streetname, we would need additional address parsing, which would require a bigger change
- so maybe we should consider keeping the original address
> note that `betanyc_categories` and `betanyc_subcategories` will be truncated in the shapefile