### PR TITLE
Group by week to resolve different day-of-week end

### DIFF
--- a/recipes/opportunity_insights/build_weekly.py
+++ b/recipes/opportunity_insights/build_weekly.py
@@ -17,17 +17,6 @@ df2 = pd.read_csv(
     na_values='.'
 )
 
-'''
-# Filter to NYC and set FIPS code as index
-dfs = [df1, df2]
-counties = region_dict.keys()
-dfs = [df[df.countyfips.isin(counties)].set_index(["countyfips","year","month","day_endofweek"], drop=True) for df in dfs]
-
-# Concatenate tables and reset index
-merged = pd.concat(dfs, axis=1, join='outer', copy=False)
-merged.reset_index(drop=False, inplace=True)
-'''
-
 counties = region_dict.keys()
 df1 = df1[df1.countyfips.isin(counties)]
 df2 = df2[df2.countyfips.isin(counties)]

--- a/recipes/opportunity_insights/build_weekly.py
+++ b/recipes/opportunity_insights/build_weekly.py
@@ -17,6 +17,7 @@ df2 = pd.read_csv(
     na_values='.'
 )
 
+'''
 # Filter to NYC and set FIPS code as index
 dfs = [df1, df2]
 counties = region_dict.keys()
@@ -25,6 +26,12 @@ dfs = [df[df.countyfips.isin(counties)].set_index(["countyfips","year","month","
 # Concatenate tables and reset index
 merged = pd.concat(dfs, axis=1, join='outer', copy=False)
 merged.reset_index(drop=False, inplace=True)
+'''
+
+counties = region_dict.keys()
+df1 = df1[df1.countyfips.isin(counties)]
+df2 = df2[df2.countyfips.isin(counties)]
+merged = pd.merge(df1, df2,  how='outer', on=["countyfips","year","month","day_endofweek"])
 
 # Add county names
 merged['county']= merged['countyfips'].map(region_dict)

--- a/recipes/opportunity_insights/create_weekly.sql
+++ b/recipes/opportunity_insights/create_weekly.sql
@@ -1,8 +1,8 @@
 CREATE TEMP TABLE tmp (
-    fipscounty text,
     year text,
     month text,
     day_endofweek text,
+    fipscounty text,
     engagement numeric,
     badges numeric,
     break_engagement numeric,
@@ -49,13 +49,14 @@ SELECT
     TO_CHAR(
         CONCAT_WS('-',year,LPAD(month,2,'0'),LPAD(day_endofweek,2,'0'))::date, 
         'IYYY-IW') as year_week,
-    fipscounty,
-    initial_claims as ui_claims,
-    initial_claims_rate as ui_claims_rate,
-    engagement as zearn_engagement,
-    badges as zearn_badges
+    SUM(initial_claims) as ui_claims,
+    SUM(initial_claims_rate) as ui_claims_rate,
+    SUM(engagement) as zearn_engagement,
+    SUM(badges) as zearn_badges
 INTO :NAME.:"VERSION"
-FROM tmp;
+FROM tmp
+GROUP BY fipscounty, county, year_week
+ORDER BY fips_county, year_week;
 
 DROP VIEW IF EXISTS :NAME.latest;
 CREATE VIEW :NAME.latest AS (


### PR DESCRIPTION
Join was on the day of the end of the week, rather than the week number. One dataset had weeks end on Sunday, the other had weeks end on Saturday.