### PR TITLE
Foursquare: Round-two normalization

### DIFF
--- a/recipes/foursquare/create_county.sql
+++ b/recipes/foursquare/create_county.sql
@@ -5,7 +5,7 @@ CREATE TEMP TABLE tmp (
     state text,
     borough text,
     categoryid text,
-    categoryname text,
+    category text,
     demo text,
     visits numeric,
     avgDuration numeric,
@@ -30,7 +30,7 @@ CREATE TABLE :NAME.:"VERSION" AS(
             WHEN borough = 'Queens' THEN 'QN'
             WHEN borough = 'Staten Island' THEN 'SI'
         END) as borough,
-        categoryname,
+        category,
         SUM(CASE WHEN demo = 'All' THEN visits END) AS visits_all,
         SUM(CASE WHEN demo = 'Below65' THEN visits END) AS visits_u65,
         SUM(CASE WHEN demo = 'Above65' THEN visits END) AS visits_o65,
@@ -38,14 +38,14 @@ CREATE TABLE :NAME.:"VERSION" AS(
         SUM(CASE WHEN demo = 'Below65' THEN avgduration END) AS duration_avg_u65,
         SUM(CASE WHEN demo = 'Above65' THEN avgduration END) AS duration_avg_o65
     FROM tmp
-    GROUP BY date, borough, categoryname
+    GROUP BY date, borough, category
 );
 
 DROP TABLE IF EXISTS :NAME.daily_county CASCADE;
 SELECT 
     date,
     borough,
-    categoryname,
+    category,
     SUM(visits_all) AS visits_all,
     SUM(visits_u65) AS visits_u65,
     SUM(visits_o65) AS visits_o65,
@@ -54,12 +54,12 @@ SELECT
     ROUND(SUM(duration_avg_o65*visits_o65)/SUM(visits_o65), 2)as duration_avg_o65
 INTO :NAME.daily_county
 FROM :NAME.:"VERSION"
-GROUP BY date, borough, categoryname;
+GROUP BY date, borough, category;
 
 DROP TABLE IF EXISTS :NAME.weekly_county CASCADE;
 SELECT 
     to_char(date::date, 'IYYY-IW') year_week,
-    borough, categoryname, 
+    borough, category, 
     AVG(visits_all) AS visits_avg_all,
     AVG(visits_u65) AS visits_avg_u65,
     AVG(visits_o65) AS visits_avg_o65,
@@ -68,7 +68,7 @@ SELECT
     ROUND(SUM(duration_avg_o65*visits_o65)/SUM(visits_o65), 2)as duration_avg_o65
 INTO :NAME.weekly_county
 FROM :NAME.:"VERSION"
-GROUP BY year_week, borough, categoryname;
+GROUP BY year_week, borough, category;
 
 DROP VIEW IF EXISTS :NAME.latest;
 CREATE VIEW :NAME.latest AS (

--- a/recipes/foursquare/create_county.sql
+++ b/recipes/foursquare/create_county.sql
@@ -30,6 +30,13 @@ CREATE TABLE :NAME.:"VERSION" AS(
             WHEN borough = 'Queens' THEN 'QN'
             WHEN borough = 'Staten Island' THEN 'SI'
         END) as borough,
+        (CASE 
+            WHEN borough = 'Bronx County' THEN 2
+            WHEN borough = 'Brooklyn' THEN 3
+            WHEN borough = 'New York' THEN 1
+            WHEN borough = 'Queens' THEN 4
+            WHEN borough = 'Staten Island' THEN 5
+        END) as borocode,
         category,
         SUM(CASE WHEN demo = 'All' THEN visits END) AS visits_all,
         SUM(CASE WHEN demo = 'Below65' THEN visits END) AS visits_u65,
@@ -45,6 +52,7 @@ DROP TABLE IF EXISTS :NAME.daily_county CASCADE;
 SELECT 
     date,
     borough,
+    borocode,
     category,
     SUM(visits_all) AS visits_all,
     SUM(visits_u65) AS visits_u65,
@@ -54,12 +62,14 @@ SELECT
     ROUND(SUM(duration_avg_o65*visits_o65)/SUM(visits_o65), 2)as duration_avg_o65
 INTO :NAME.daily_county
 FROM :NAME.:"VERSION"
-GROUP BY date, borough, category;
+GROUP BY date, borough, borocode, category;
 
 DROP TABLE IF EXISTS :NAME.weekly_county CASCADE;
 SELECT 
     to_char(date::date, 'IYYY-IW') year_week,
-    borough, category, 
+    borough, 
+    borocode,
+    category, 
     AVG(visits_all) AS visits_avg_all,
     AVG(visits_u65) AS visits_avg_u65,
     AVG(visits_o65) AS visits_avg_o65,
@@ -68,7 +78,7 @@ SELECT
     ROUND(SUM(duration_avg_o65*visits_o65)/SUM(visits_o65), 2)as duration_avg_o65
 INTO :NAME.weekly_county
 FROM :NAME.:"VERSION"
-GROUP BY year_week, borough, category;
+GROUP BY year_week, borough, borocode, category;
 
 DROP VIEW IF EXISTS :NAME.latest;
 CREATE VIEW :NAME.latest AS (

--- a/recipes/foursquare/init.sql
+++ b/recipes/foursquare/init.sql
@@ -54,7 +54,7 @@ BEGIN
                     END)
                 from city_zip_boro a where zip=a.zipcode) as borocode,
                 categoryname as category,
-                hour,
+                hour as timeofday,
                 demo,
                 ROUND(visits, 0) AS visits,
                 avgduration,
@@ -133,23 +133,24 @@ BEGIN
             SELECT 
                 date,
                 year_week, 
+                day_of_week,
                 zipcode,
                 borough, 
                 borocode,
                 category,
-                ROUND(SUM(CASE WHEN demo='Below65' AND hour='All' THEN visits END),0) AS visits_u65,
-                ROUND(SUM(CASE WHEN demo='Above65' AND hour='All' THEN visits END),0) AS visits_o65,
-                ROUND(SUM(CASE WHEN demo='All' AND hour='Morning' THEN visits END),0) AS visits_morning,
-                ROUND(SUM(CASE WHEN demo='All' AND hour='Late Morning' THEN visits END),0) AS visits_latemorning,
-                ROUND(SUM(CASE WHEN demo='All' AND hour='Early Afternoon' THEN visits END),0) AS visits_earlyafternoon,
-                ROUND(SUM(CASE WHEN demo='All' AND hour='Late Afternoon' THEN visits END),0) AS visits_lateafternoon,
-                ROUND(SUM(CASE WHEN demo='All' AND hour='Evening' THEN visits END),0) AS visits_evening,
-                ROUND(SUM(CASE WHEN demo='All' AND hour='Late Evening' THEN visits END),0) AS visits_lateevening,
-                ROUND(SUM(CASE WHEN demo='All' AND hour='Night' THEN visits END),0) AS visits_night,
-                ROUND(SUM(CASE WHEN demo='All' AND hour='Late Night' THEN visits END),0) AS visits_latenight
+                ROUND(SUM(CASE WHEN demo='All' AND timeofday='All' THEN visits END),0) AS visits_all,
+                ROUND(SUM(CASE WHEN demo='All' AND timeofday='Morning' THEN visits END),0) AS visits_morning,
+                ROUND(SUM(CASE WHEN demo='All' AND timeofday='Late Morning' THEN visits END),0) AS visits_latemorning,
+                ROUND(SUM(CASE WHEN demo='All' AND timeofday='Early Afternoon' THEN visits END),0) AS visits_earlyafternoon,
+                ROUND(SUM(CASE WHEN demo='All' AND timeofday='Late Afternoon' THEN visits END),0) AS visits_lateafternoon,
+                ROUND(SUM(CASE WHEN demo='All' AND timeofday='Evening' THEN visits END),0) AS visits_evening,
+                ROUND(SUM(CASE WHEN demo='All' AND timeofday='Late Evening' THEN visits END),0) AS visits_lateevening,
+                ROUND(SUM(CASE WHEN demo='All' AND timeofday='Night' THEN visits END),0) AS visits_night,
+                ROUND(SUM(CASE WHEN demo='All' AND timeofday='Late Night' THEN visits END),0) AS visits_latenight
             FROM (
                 SELECT
                     date,
+                    date_part('dow', date) as day_of_week,
                     to_char(date::date, 'IYYY-IW') as year_week,
                     zip as zipcode, 
                     (SELECT boro from city_zip_boro a where zip=a.zipcode) as borough,
@@ -163,12 +164,13 @@ BEGIN
                         END)
                     from city_zip_boro a where zip=a.zipcode) as borocode,
                     categoryname as category,
-                    hour, demo,
+                    hour as timeofday, 
+                    demo,
                     avg(visits) as visits
                 FROM foursquare_zipcode.main
-                GROUP BY date, to_char(date::date, 'IYYY-IW'), hour, demo, zip, borough, borocode, category
+                GROUP BY date, year_week, day_of_week, hour, demo, zip, borough, borocode, category
             ) a
-            GROUP BY date, year_week, zipcode, borough, borocode, category
+            GROUP BY date, year_week, day_of_week, zipcode, borough, borocode, category
         );
         RAISE NOTICE 'Creating foursquare_zipcode.daily_zipcode_timeofday';
     ELSE RAISE NOTICE 'foursquare_zipcode.daily_zipcode_timeofday is created';

--- a/recipes/foursquare/init.sql
+++ b/recipes/foursquare/init.sql
@@ -41,7 +41,7 @@ BEGIN
             SELECT 
                 date,
                 to_char(date::date, 'IYYY-IW') as year_week,
-                date_part('dow', date) as day_of_week,
+                date_part('dow', date) as dayofweek,
                 zip as zipcode,
                 (SELECT boro from city_zip_boro a where zip=a.zipcode) as borough,
                 (SELECT 
@@ -133,7 +133,7 @@ BEGIN
             SELECT 
                 date,
                 year_week, 
-                day_of_week,
+                dayofweek,
                 zipcode,
                 borough, 
                 borocode,
@@ -150,7 +150,7 @@ BEGIN
             FROM (
                 SELECT
                     date,
-                    date_part('dow', date) as day_of_week,
+                    date_part('dow', date) as dayofweek,
                     to_char(date::date, 'IYYY-IW') as year_week,
                     zip as zipcode, 
                     (SELECT boro from city_zip_boro a where zip=a.zipcode) as borough,
@@ -168,9 +168,9 @@ BEGIN
                     demo,
                     avg(visits) as visits
                 FROM foursquare_zipcode.main
-                GROUP BY date, year_week, day_of_week, hour, demo, zip, borough, borocode, category
+                GROUP BY date, year_week, dayofweek, hour, demo, zip, borough, borocode, category
             ) a
-            GROUP BY date, year_week, day_of_week, zipcode, borough, borocode, category
+            GROUP BY date, year_week, dayofweek, zipcode, borough, borocode, category
         );
         RAISE NOTICE 'Creating foursquare_zipcode.daily_zipcode_timeofday';
     ELSE RAISE NOTICE 'foursquare_zipcode.daily_zipcode_timeofday is created';

--- a/recipes/foursquare/init.sql
+++ b/recipes/foursquare/init.sql
@@ -90,9 +90,9 @@ BEGIN
                     END)
                 from city_zip_boro a where zip=a.zipcode) as borocode,
                 categoryname as category,
-                ROUND(avg(CASE WHEN demo='All' THEN visits END),0) AS visits_avg_all,
-                ROUND(avg(CASE WHEN demo='Below65' THEN visits END),0) AS visits_avg_u65,
-                ROUND(avg(CASE WHEN demo='Above65' THEN visits END),0) AS visits_avg_o65
+                SUM(CASE WHEN demo='All' THEN visits END) AS visits_all,
+                SUM(CASE WHEN demo='Below65' THEN visits END) AS visits_u65,
+                SUM(CASE WHEN demo='Above65' THEN visits END) AS visits_o65
             FROM foursquare_zipcode.main
             WHERE hour = 'All'
             GROUP BY date, zip, category

--- a/recipes/foursquare/runner_zipcode.sh
+++ b/recipes/foursquare/runner_zipcode.sh
@@ -65,7 +65,28 @@ function foursquare_zipcode {
                 ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_daily_zipcode_timeofday.csv
 
                 psql $RDP_DATA -c "\COPY (
-                    SELECT * FROM $NAME.latest
+                    SELECT 
+                        date,
+                        day_of_week,
+                        year_week,
+                        zipcode,
+                        borough,
+                        borocode,
+                        category,
+                        timeofday,
+                        visits,
+                        avgduration,
+                        medianduration,
+                        pctto10mins,
+                        pctto20mins,
+                        pctto30mins,
+                        pctto60mins,
+                        pctto2hours,
+                        pctto4hours,
+                        pctto8hours,
+                        pctover8hours
+                    FROM $NAME.latest
+                    WHERE demo='All'
                 ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_daily_zipcode_raw.csv
 
                 # Write VERSION info

--- a/recipes/foursquare/runner_zipcode.sh
+++ b/recipes/foursquare/runner_zipcode.sh
@@ -74,7 +74,7 @@ function foursquare_zipcode {
                         borocode,
                         category,
                         timeofday,
-                        visits,
+                        visits as visits_all,
                         avgduration,
                         medianduration,
                         pctto10mins,


### PR DESCRIPTION
#73 

+ Change `categoryname` to `category` in county-level tables
    + All views that get exported in the zipcode-level tables already change `categoryname` to `category`.
+ Add borocode to foursquare_daily_county and foursquare_weekly_county
+ Remove "_avg" from field names: `visits_avg_all` , `visits_avg_u65` and `visits_avg_o65` in foursquare_daily_zipcode
+ Add `day_of_week ` field to include day of the week in foursquare_daily_zipcode_timeofday
+ Remove `visits_u65` and `visits_o65` and add `visits_all` from foursquare_daily_zipcode_timeofday
+ Rename `hour` to `timeofday` in foursquare_daily_zipcode_raw
+ Remove `demo` field from foursquare_daily_zipcode_raw and only include records where demo = "All" 
+ rename 'visits' to `visits_all` in foursquare_daily_zipcode_raw
