### PR TITLE
162/163: Modify index workflow to include submarkets

### DIFF
--- a/recipes/street_easy/build_rental_sales_index.py
+++ b/recipes/street_easy/build_rental_sales_index.py
@@ -3,20 +3,24 @@ import sys
 import datetime
 import pandas as pd
 
+BASE_URL='https://streeteasy-market-data-download.s3.amazonaws.com'
 URL_STREET_EASY=os.environ['URL_STREET_EASY']
+URL=f'{BASE_URL}/{URL_STREET_EASY}'
+
+# Calculate last month
 this_month = datetime.date.today().replace(day=1)
 last_month = this_month - datetime.timedelta(days=1)
 VERSION = last_month.strftime("%Y-%m")
 
 try:
-    url = f"{URL_STREET_EASY}price_indices-{VERSION}.csv"
+    url = f"{URL}/price_indices-{VERSION}.csv"
     all_rows = pd.read_csv(url, dtype=str)
 except:
     last_month = last_month.replace(day=1)
     PREV_VERSION = (last_month.replace(month=last_month.month-1)).strftime("%Y-%m")
 
     # Data for {VERSION} is not available yet, trying {PREV_VERSION}
-    url = f"{URL_STREET_EASY}price_indices-{PREV_VERSION}.csv"
+    url = f"{URL}/price_indices-{PREV_VERSION}.csv"
     all_rows = pd.read_csv(url, dtype=str)
 
 r = all_rows[all_rows['TYPE']=='rentals'].rename(columns={"index": "rental_index"})

--- a/recipes/street_easy/create_rental_sales_index.sql
+++ b/recipes/street_easy/create_rental_sales_index.sql
@@ -37,16 +37,16 @@ FROM tmp;
 
 -- Create view containing just submarkets
 DROP VIEW IF EXISTS :NAME.monthly_rental_sales_index_submkt;
-CREATE VIEW :NAME.latest AS (
-    SELECT :'VERSION' as v, * 
+CREATE VIEW :NAME.monthly_rental_sales_index_submkt AS (
+    SELECT * 
     FROM :NAME.:"VERSION"
     WHERE submarket NOT IN ('Queens', 'Staten Island', 'Manhattan', 'Bronx', 'NYC')
 ); 
 
 -- Create view containing boroughs and NYC
 DROP VIEW IF EXISTS :NAME.monthly_rental_sales_index_boro;
-CREATE VIEW :NAME.latest AS (
-    SELECT :'VERSION' as v,
+CREATE VIEW :NAME.monthly_rental_sales_index_boro AS (
+    SELECT
         year_month,
         borough,
         borocode,

--- a/recipes/street_easy/runner.sh
+++ b/recipes/street_easy/runner.sh
@@ -73,8 +73,12 @@ BASEDIR=$(dirname $0)
 
             # Export to CSV
             psql $RDP_DATA -c "\COPY (
-                SELECT * FROM $NAME.\"$VERSION\"
-            ) TO stdout DELIMITER ',' CSV HEADER;" > streeteasy_monthly_rental_sales_index.csv
+                SELECT * FROM $NAME.monthly_rental_sales_index_submkt
+            ) TO stdout DELIMITER ',' CSV HEADER;" > streeteasy_monthly_rental_sales_index_submkt.csv
+
+            psql $RDP_DATA -c "\COPY (
+                SELECT * FROM $NAME.monthly_rental_sales_index_boro
+            ) TO stdout DELIMITER ',' CSV HEADER;" > streeteasy_monthly_rental_sales_index_boro.csv
 
         )
     ) 


### PR DESCRIPTION
#163 #162 

This PR:
+ Changes data download in the python script to account for new input data location
    + Assumes that the street easy data location will get stored in the env var `URL_STREET_EASY`
    + First, the script tries to download data versioned from last month. If the data does not exist, it will use data from two months ago
+  Adjusts python merge procedures to account for the new input data format
    + Data no longer needs un-pivoting
    + Splits into sales and rentals records, then merges on submarket and date
+ Transfers index data with new submarket column to postgres
+ Creates a versioned table containing all records (both submarket- and borough-level)
+ Creates two views to export to csv
   + `monthly_rental_sales_index_submkt` contains only data at the submarket level
   + `monthly_rental_sales_index_boro` contains data at the borough and city level to match current output
