### PR TITLE
196 mastercard

### DIFF
--- a/recipes/mastercard/create_mastercard.sql
+++ b/recipes/mastercard/create_mastercard.sql
@@ -8,7 +8,7 @@ CREATE TABLE mastercard.zip_to_borough (
         borocode int
     );
 COMMIT;
-BEGIN TRANSACTION
+BEGIN;
 
  
 INSERT INTO mastercard.zip_to_borough values ('10471','BX',2);
@@ -28,7 +28,6 @@ INSERT INTO mastercard.zip_to_borough values ('10457','BX',2);
 INSERT INTO mastercard.zip_to_borough values ('10460','BX',2);
 INSERT INTO mastercard.zip_to_borough values ('10452','BX',2);
 INSERT INTO mastercard.zip_to_borough values ('10456','BX',2);
-INSERT INTO mastercard.zip_to_borough values ('10471','BX',2);
 INSERT INTO mastercard.zip_to_borough values ('10472','BX',2);
 INSERT INTO mastercard.zip_to_borough values ('10459','BX',2);
 INSERT INTO mastercard.zip_to_borough values ('10451','BX',2);
@@ -260,10 +259,10 @@ INSERT INTO mastercard.zip_to_borough values ('10312','SI',5);
 INSERT INTO mastercard.zip_to_borough values ('10309','SI',5);
 INSERT INTO mastercard.zip_to_borough values ('10307','SI',5);
 INSERT INTO mastercard.zip_to_borough values ('10310','SI',5);
-END TRANSACTION;
+COMMIT;
 
 
-BEGIN TRANSACTION;
+BEGIN;
 CREATE TEMP TABLE tmp_csv (
     yr numeric,
     txn_date date,
@@ -343,4 +342,4 @@ SELECT
 INTO :NAME.:"VERSION"  FROM tmp_csv as tmp 
 INNER JOIN mastercard.zip_to_borough as zip ON tmp.Zip_code = zip.zip_code;
 
-END TRANSACTION;
+COMMIT;

--- a/recipes/mastercard/runner.sh
+++ b/recipes/mastercard/runner.sh
@@ -11,6 +11,7 @@ AWS_DEFAULT_REGION=us-east-1
 
 
 (      
+    
     cd $BASEDIR
     mkdir -p input
     mkdir -p output
@@ -65,7 +66,7 @@ AWS_DEFAULT_REGION=us-east-1
     echo "unzipping " $FULL_FILENAME
     #unzips the first file by chronological order by sorting by modified date, reversed, and taking the tail to avoid the header
     # Then use awk to select filename.
-    unzip -d /input -P $MASTERCARD_PASSWORD $FULL_FILENAME
+    unzip -d /input -P $MASTERCARD_PASSWORD $FULL_FILENAME || exit 519
     #removes all downloaded non-csv files.
     rm $(find $BASEDIR/input -type f -not -name "*.csv")
     #cd $BASEDIR
@@ -104,6 +105,6 @@ AWS_DEFAULT_REGION=us-east-1
     if [ "$AWS_ERROR" -eq 1 ]
     then
         echo "Sharepoint upload successfull but failed to upload to AWS.";
-        raise 1;
+        exit 435;
     fi
 )


### PR DESCRIPTION
#196 improved error handling. You can't see what is being echoed but you can see exit codes. Changed 'raise 1' to 'exit 435' when AWS upload fails.

Also removed duplicate zip codes in SQL file resulting in double entries.