### PR TITLE
install openpyxl within linkedin pipeline

### DIFF
--- a/recipes/linkedin/runner.sh
+++ b/recipes/linkedin/runner.sh
@@ -4,6 +4,10 @@ BASEDIR=$(dirname $0)
 NAME=$(basename $BASEDIR)
 VERSION=$DATE
 
+# install new dependency
+# added to requirements.txt also, but it won't work until the docker image is rebuilt
+pip install openpyxl
+
 (
     cd $BASEDIR
     mkdir -p output

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ gspread
 oauth2client
 pydrive
 office365-rest-client
+openpyxl


### PR DESCRIPTION
#230 

Adding pip install openpyxl in linkedin's runner.sh
Also added it to requirements.txt. If docker image is built with the updated requirements.txt, then I'll need to remove pip install from runner.sh