### PR TITLE
replaced county pipline with new file endpoint  and new schema taken …

### DIFF
--- a/recipes/foursquare/create_county_2.sql
+++ b/recipes/foursquare/create_county_2.sql
@@ -1,0 +1,205 @@
+/*
+Cube Dimension Keys:
+dt - date in YYYY-MM-DD format
+country - ISO country code (data should be provided for US only)
+state - State + DC
+county - county
+zip - zipcode
+categoryid - foursquare category ID or 'Group' placeholder for special groupings
+categoryname - category name or group name + overall rollup
+hour - hour of day of visits + overall rollup
+demo - demographic group of visitors + overall rollup
+
+Data:
+visits - normalized visitors
+avgDuration - average linger time of visitors
+medianDuration - 50th percentile linger time of visitors
+pctTo10Mins - normalized visitors lingering < 10 minutes
+pctTo20Mins - normalized visitors lingering > 10 and < 20 minutes
+pctTo30Mins - normalized visitors lingering > 20 and < 30 minutes
+pctTo60Mins - normalized visitors lingering > 30 and < 60 minutes
+pctTo2Hours - normalized visitors lingering > 1 and < 2 hours
+pctTo4Hours - normalized visitors lingering > 2 and < 4 hours
+pctTo8Hours - normalized visitors lingering > 4 and < 8 hours
+pctOver8Hours - normalized visitors lingering more than 8 hours
+
+Time of Day Definitions:
+
+Morning: 6am to 8:59am
+Late Morning: 9am to 11:59am
+Early Afternoon: 12pm to 2:59pm
+Late Afternoon: 3pm to 4:59pm
+Evening: 5pm to 7:59pm
+Late Evening: 8pm to 10:59pm
+Night: 11pm to 2:59am
+Late Night: 3am to 5:59am
+*/
+BEGIN;
+
+CREATE TEMP TABLE tmp (
+    date date,
+    country text,
+    state text,
+    county text,
+    zip text,
+    categoryid text,
+    categoryname text,
+    hour text,
+    demo text,
+    visits text,
+    avgDuration text,
+    medianDuration text,
+    pctTo10Mins text,
+    pctTo20Mins text,
+    pctTo30Mins text,
+    pctTo60Mins text,
+    pctTo2Hours text,
+    pctTo4Hours text,
+    pctTo8Hours text,
+    pctOver8Hours text
+);
+
+\COPY tmp FROM PSTDIN WITH NULL AS '' DELIMITER ',' CSV;
+
+--DELETE FROM tmp WHERE categoryid != 'Group';
+
+--ALTER TABLE tmp 
+
+
+/* Create maintable */
+CREATE SCHEMA IF NOT EXISTS :NAME;
+DROP TABLE IF EXISTS :NAME.:"VERSION" CASCADE;
+SELECT 
+    --SPLIT_PART(tmp.date, '-', 1)::date as date,
+    date,
+    country,
+    state,
+    county,
+    (CASE 
+           WHEN county = 'Bronx' AND state = 'New York' THEN 'BX'
+           WHEN county = 'Kings' AND state = 'New York' THEN 'BK'
+           WHEN county = 'New York' AND state = 'New York' THEN 'MN'
+           WHEN county = 'Queens' AND state = 'New York' THEN 'QN'
+           WHEN county = 'Richmond' AND state = 'New York' THEN 'SI'
+           ELSE ''
+       END) as borough,
+    (CASE    
+           WHEN county = 'Bronx' AND state = 'New York' THEN 2
+           WHEN county = 'Kings' AND state = 'New York' THEN 3
+           WHEN county = 'New York' AND state = 'New York' THEN 1
+           WHEN county = 'Queens' AND state = 'New York' THEN 4
+           WHEN county = 'Richmond' AND state = 'New York' THEN 5
+           ELSE 0
+       END) as borocode,
+    categoryname,
+    hour,
+    demo,
+    nullif(visits, '')::numeric AS visits,
+    nullif(avgDuration, '')::numeric AS avgDuration,
+    nullif(medianDuration, '')::numeric AS medianDuration,
+    nullif(pctTo10Mins, '')::numeric AS pctTo10Mins,
+    nullif(pctTo20Mins, '')::numeric AS pctTo20Mins,
+    nullif(pctTo30Mins, '')::numeric AS pctTo30Mins,
+    nullif(pctTo60Mins, '')::numeric AS pctTo60Mins,
+    nullif(pctTo2Hours, '')::numeric AS pctTo2Hours,
+    nullif(pctTo4Hours, '')::numeric AS pctTo4Hours,
+    nullif(pctTo8Hours, '')::numeric AS pctTo8Hours,
+    nullif(pctOver8Hours, '')::numeric AS pctOver8Hours
+INTO :NAME.:"VERSION" FROM tmp
+WHERE state = 'New York' AND county IN ('Bronx', 'Kings', 'New York', 'Queens', 'Richmond'); 
+
+/* ---this is from create_county.sql
+
+DROP TABLE IF EXISTS :NAME.daily_county CASCADE;
+SELECT 
+    date,
+    borough,
+    borocode,
+    category,
+    SUM(visits_all) AS visits_all,
+    SUM(visits_u65) AS visits_u65,
+    SUM(visits_o65) AS visits_o65,
+    ROUND(SUM(duration_avg_all*visits_all)/SUM(visits_all), 2) as duration_avg_all,
+    ROUND(SUM(duration_avg_u65*visits_u65)/SUM(visits_u65), 2) as duration_avg_u65,
+    ROUND(SUM(duration_avg_o65*visits_o65)/SUM(visits_o65), 2)as duration_avg_o65
+INTO :NAME.daily_county
+FROM :NAME.:"VERSION"
+GROUP BY date, borough, borocode, category;
+
+DROP TABLE IF EXISTS :NAME.weekly_county CASCADE;
+SELECT 
+    to_char(date::date, 'IYYY-IW') year_week,
+    borough, 
+    borocode,
+    category, 
+    AVG(visits_all) AS visits_avg_all,
+    AVG(visits_u65) AS visits_avg_u65,
+    AVG(visits_o65) AS visits_avg_o65,
+    ROUND(SUM(duration_avg_all*visits_all)/SUM(visits_all), 2) as duration_avg_all,
+    ROUND(SUM(duration_avg_u65*visits_u65)/SUM(visits_u65), 2) as duration_avg_u65,
+    ROUND(SUM(duration_avg_o65*visits_o65)/SUM(visits_o65), 2)as duration_avg_o65
+INTO :NAME.weekly_county
+FROM :NAME.:"VERSION"
+GROUP BY year_week, borough, borocode, category;
+
+DROP VIEW IF EXISTS :NAME.latest;
+CREATE VIEW :NAME.latest AS (
+    SELECT :'VERSION' as v, * 
+    FROM :NAME.:"VERSION"
+);
+*/
+
+/* Insert records into the Main table */
+--DELETE FROM :NAME.main WHERE date = :'VERSION';
+--INSERT INTO :NAME.main SELECT * FROM :NAME.:"VERSION";
+
+DROP TABLE IF EXISTS :NAME.daily_county CASCADE;
+SELECT
+    date,
+    country,
+    state,
+    county,
+    borough,
+    borocode,
+    categoryname,
+    AVG(visits) as visits,
+    AVG(avgDuration) as avgDuration,
+    AVG(medianDuration) as medianDuration,
+    AVG(pctTo10Mins) as pctTo10Mins,
+    AVG(pctTo20Mins) as pctTo20Mins,
+    AVG(pctTo30Mins) as pctTo30Mins,
+    AVG(pctTo60Mins) as pctTo60Mins,
+    AVG(pctTo2Hours) as pctTo2Hours,
+    AVG(pctTo4Hours) as pctTo4Hours,
+    AVG(pctTo8Hours) as pctTo8Hours,
+    AVG(pctOver8Hours) as pctOver8Hours
+INTO :NAME.daily_county
+FROM :NAME.:"VERSION"
+GROUP BY date, country, state, county, borough, borocode, categoryname;
+
+
+DROP TABLE IF EXISTS :NAME.weekly_county CASCADE;
+SELECT 
+    to_char(date::date, 'IYYY-IW') year_week,
+    country,
+    state,
+    county,
+    borough,
+    borocode,
+    categoryname,
+    AVG(visits) as visits,
+    AVG(avgDuration) as avgDuration,
+    AVG(medianDuration) as medianDuration,
+    AVG(pctTo10Mins) as pctTo10Mins,
+    AVG(pctTo20Mins) as pctTo20Mins,
+    AVG(pctTo30Mins) as pctTo30Mins,
+    AVG(pctTo60Mins) as pctTo60Mins,
+    AVG(pctTo2Hours) as pctTo2Hours,
+    AVG(pctTo4Hours) as pctTo4Hours,
+    AVG(pctTo8Hours) as pctTo8Hours,
+    AVG(pctOver8Hours) as pctOver8Hours
+INTO :NAME.weekly_county
+FROM :NAME.:"VERSION"
+GROUP BY year_week, country, state, county, borough, borocode, categoryname;   
+
+COMMIT;

--- a/recipes/foursquare/create_county_2.sql
+++ b/recipes/foursquare/create_county_2.sql
@@ -160,7 +160,7 @@ GROUP BY year_week, country, state, county, borough, borocode, categoryname;
 
 DROP VIEW IF EXISTS :NAME.latest;
 CREATE VIEW :NAME.latest AS (
-    SELECT :"VERSION" as v, * 
+    SELECT :'VERSION' as v, * 
     FROM :NAME.:"VERSION"
     );
 END TRANSACTION;

--- a/recipes/foursquare/datacube.py
+++ b/recipes/foursquare/datacube.py
@@ -4,6 +4,7 @@ from oauth2client.service_account import ServiceAccountCredentials
 from sqlalchemy import create_engine
 import pandas as pd
 import os
+import re
 
 # Authenticate google api service
 gauth = GoogleAuth()
@@ -40,7 +41,11 @@ loaded=pd.read_sql(sql='''
 loaded_dates=loaded.table_name.to_list()
 
 for i in available_dates:
+    #remove the below statement and all data will load for all available dates.
     if i not in loaded_dates:
+        #check to make sure date format is valid.
+        if ((re.search(r'\d{4}-\d{2}-\d{2}', i)) is None):
+            continue
         print(f'pulling date {i}')
         file_id=df.loc[df.date == i, 'id'].to_list()[0]
         file_name=f'{i}.tar.gz'
@@ -51,4 +56,4 @@ for i in available_dates:
         # Write content string to directory
         with open(f'input/{file_name}', 'wb') as fi:
             fi.write(content_string)
-    
+    #if available date is in loaded dates, nothing will write to input, and runner will say "the database is up-to-date!"

--- a/recipes/foursquare/init.sql
+++ b/recipes/foursquare/init.sql
@@ -1,12 +1,17 @@
 DO $$
 DECLARE
     _main boolean;
+    _main_county_daily boolean;
+    _main_county_weekly boolean;
     _latest boolean;
     _view_weekly_zipcode boolean;
     _view_daily_zipcode boolean;
     _view_daily_zipcode_timeofday boolean;
+    
 BEGIN
     SELECT 'foursquare_zipcode.main' IN (SELECT table_schema||'.'||table_name FROM information_schema.tables) INTO _main;    
+    SELECT 'foursquare_county.main_county_daily' IN (SELECT table_schema||'.'||table_name FROM information_schema.tables) INTO _main_county_daily;    
+    SELECT 'foursquare_county.main_county_weekly' IN (SELECT table_schema||'.'||table_name FROM information_schema.tables) INTO _main_county_weekly;    
     SELECT 'foursquare_zipcode.latest' IN (SELECT table_schema||'.'||table_name FROM information_schema.tables) INTO _latest;    
     SELECT 'foursquare_zipcode.daily_zipcode'  IN (SELECT table_schema||'.'||table_name FROM information_schema.tables) INTO _view_daily_zipcode;
     SELECT 'foursquare_zipcode.weekly_zipcode' IN (SELECT table_schema||'.'||table_name FROM information_schema.tables) INTO _view_weekly_zipcode;
@@ -34,6 +39,59 @@ BEGIN
         );
         RAISE NOTICE 'Creating foursquare_zipcode.main';
     ELSE RAISE NOTICE 'foursquare_zipcode.main is created';
+    END IF;
+
+     IF NOT _main_county_daily THEN
+        CREATE SCHEMA IF NOT EXISTS foursquare_county;
+        CREATE TABLE foursquare_county.main_county_daily (
+            data_date date,
+            country text,
+            state text,
+            county text,
+            borough text NULL,
+            borocode int NULL,
+            categoryname text,
+            visits numeric,
+            avgduration numeric,
+            medianduration numeric,
+            pctto10mins numeric,
+            pctto20mins numeric,
+            pctto30mins numeric,
+            pctto60mins numeric,
+            pctto2hours numeric,
+            pctto4hours numeric,
+            pctto8hours numeric,
+            pctover8hours numeric
+        );
+        RAISE NOTICE 'Creating main_county_daily';
+    ELSE RAISE NOTICE 'main_county_daily already created';
+    END IF;
+
+    IF NOT _main_county_weekly THEN
+        CREATE SCHEMA IF NOT EXISTS foursquare_county;
+        CREATE TABLE foursquare_county.main_county_weekly (
+            year_week text,
+            country text,
+            state text,
+            county text,
+            borough text NULL,
+            borocode int NULL,
+            categoryname text,
+            visits numeric,
+            avgduration numeric,
+            medianduration numeric,
+            pctto10mins numeric,
+            pctto20mins numeric,
+            pctto30mins numeric,
+            pctto60mins numeric,
+            pctto2hours numeric,
+            pctto4hours numeric,
+            pctto8hours numeric,
+            pctover8hours numeric
+        );
+
+        RAISE NOTICE 'Creating main_county_weekly';
+    ELSE RAISE NOTICE 'main_county_weekly already created';
     END IF;
 
     IF NOT _latest THEN

--- a/recipes/foursquare/runner.sh
+++ b/recipes/foursquare/runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 source $(pwd)/bin/config.sh
 source $(pwd)/recipes/foursquare/runner_zipcode.sh
-source $(pwd)/recipes/foursquare/runner_county.sh
+source $(pwd)/recipes/foursquare/runner_county_2.sh
 TYPE=$1 # zipcode/county
 
 case $TYPE in
@@ -11,6 +11,6 @@ case $TYPE in
     ;;
     county)
         # updating foursquare county
-        foursquare_county
+        foursquare_county_2
     ;;
 esac

--- a/recipes/foursquare/runner_county_2.sh
+++ b/recipes/foursquare/runner_county_2.sh
@@ -47,17 +47,13 @@ function foursquare_county_2 {
             # Export to CSV
             psql $RDP_DATA -c "\COPY (
                 SELECT * FROM $NAME.daily_county
-            ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_daily_county.csv
+            ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_latest_daily_county.csv
 
             psql $RDP_DATA -c "\COPY (
                 SELECT * FROM $NAME.weekly_county
-            ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_weekly_county.csv
+            ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_latest_weekly_county.csv
             
-            psql $RDP_DATA -c "\COPY (
-                    SELECT * FROM $NAME.latest
-            ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_daily_county_raw.csv
-            # Write VERSION info
-
+        
             psql $RDP_DATA -c "\COPY (
                     SELECT * FROM $NAME.main_county_daily
             ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_main_county_daily.csv

--- a/recipes/foursquare/runner_county_2.sh
+++ b/recipes/foursquare/runner_county_2.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+source $(pwd)/bin/config.sh
+BASEDIR=$(dirname $0)
+PARTNER=$(basename $BASEDIR)
+
+function foursquare_county_2 {
+    (
+        cd $BASEDIR
+        NAME=foursquare_county
+        
+        mc cp $GSHEET_CRED creds.json
+        mkdir -p input && mkdir -p output
+
+        psql $RDP_DATA -f init.sql
+        
+        python3 datacube.py
+
+        if [ "$(ls -A input)" ]; then
+            (
+                cd input
+
+                for file in $(ls *.tar.gz)
+                do
+                    max_bg_procs 5
+                    (
+                        echo $file
+
+                        VERSION=${file%%.*}
+                        file_name=$(tar tf $file | grep .csv.gz)
+                        tar -xvzf $file $file_name -O > $VERSION.csv.gz
+                        
+                        gunzip -dc $VERSION.csv.gz | 
+                        psql $RDP_DATA \
+                            -v NAME=$NAME \
+                            -v VERSION=$VERSION \
+                            -f ../create_county_2.sql
+                        rm $file
+                        rm $VERSION.csv.gz
+                    ) &
+                done
+                wait
+            )
+
+            (
+                cd output
+                   
+            # Export to CSV
+            psql $RDP_DATA -c "\COPY (
+                SELECT * FROM $NAME.daily_county
+            ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_daily_county.csv
+
+            psql $RDP_DATA -c "\COPY (
+                SELECT * FROM $NAME.weekly_county
+            ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_weekly_county.csv
+
+            # Write VERSION info
+            echo "$VERSION" > version.txt
+            
+            )
+            VERSION=$(cat output/version.txt)
+            Upload foursquare/$NAME $VERSION
+            Upload foursquare/$NAME latest
+            rm -rf input && rm -rf output
+            rm creds.json
+            Version $PARTNER $NAME $VERSION $NAME
+        else
+            echo "the database is up-to-date!"
+            rm -rf input && rm -rf output
+            rm creds.json
+        fi
+    )
+}

--- a/recipes/foursquare/runner_county_2.sh
+++ b/recipes/foursquare/runner_county_2.sh
@@ -52,7 +52,20 @@ function foursquare_county_2 {
             psql $RDP_DATA -c "\COPY (
                 SELECT * FROM $NAME.weekly_county
             ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_weekly_county.csv
+            
+            psql $RDP_DATA -c "\COPY (
+                    SELECT * FROM $NAME.latest
+            ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_daily_county_raw.csv
+            # Write VERSION info
 
+            psql $RDP_DATA -c "\COPY (
+                    SELECT * FROM $NAME.main_county_daily
+            ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_main_county_daily.csv
+
+            psql $RDP_DATA -c "\COPY (
+                    SELECT * FROM $NAME.main_county_weekly
+            ) TO stdout DELIMITER ',' CSV HEADER;" > foursquare_main_county_weekly.csv
+            
             # Write VERSION info
             echo "$VERSION" > version.txt
             


### PR DESCRIPTION
…from zip

#234 

Zipcode and county data are currently mixed together in the same file from the GDrive endpoint, so I borrowed from zip and county code to create a new schema for county (grouped daily and weekly), pulling it similarly to the zipcode data. Verified output in Sharepoint. Created county_2 files, but they will trigger when "foursquare county" executes so there is no need to create a new job. The original county files are left in the code base for reference. We can remove them after the pull request is accepted.